### PR TITLE
chore: align dependabot config with uv ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,16 +20,6 @@ updates:
         update-types:
           - "patch"
     versioning-strategy: increase-if-necessary
-  - package-ecosystem: pip
-    directory: "/.github/workflows"
-    schedule:
-      interval: weekly
-    commit-message:
-      prefix: "ci: "
-    groups:
-      ci:
-        patterns:
-          - "*"
   - package-ecosystem: github-actions
     directory: "/"
     schedule:


### PR DESCRIPTION
The project uses `uv` for Python dependency management, already configured via the `uv` Dependabot ecosystem.

This removes the leftover `pip` ecosystem entry, which pointed at `/.github/workflows` (no pip manifest lives there) and produced no updates. Brings the config in line with the other taps (`uv` + `github-actions` only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
