### PR TITLE
fix: Repair syncs that run without client credentials

### DIFF
--- a/tap_feefo/auth.py
+++ b/tap_feefo/auth.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from functools import cached_property
+
 from singer_sdk.authenticators import OAuthAuthenticator, SingletonMeta
 from typing_extensions import override
 
@@ -13,10 +15,36 @@ class FeefoAuthenticator(OAuthAuthenticator, metaclass=SingletonMeta):
     @property
     def oauth_request_body(self):
         return {
-            "client_id": self.config["client_id"],
-            "client_secret": self.config["client_secret"],
+            "client_id": self.client_id,
+            "client_secret": self.client_secret,
             "grant_type": "client_credentials",
         }
+
+    @cached_property
+    def _has_credentials(self) -> bool:
+        """Check that a complete pair of client credentials is available.
+
+        A warning is logged once if only one of the two credentials is
+        available.
+
+        Returns:
+            True if both a client ID and a client secret are available.
+        """
+        if self.client_id and self.client_secret:
+            return True
+
+        if self.client_id:
+            self.logger.warning(
+                "Client ID provided without a client secret, proceeding without "
+                "authentication"
+            )
+        elif self.client_secret:
+            self.logger.warning(
+                "Client secret provided without a client ID, proceeding without "
+                "authentication"
+            )
+
+        return False
 
     @classmethod
     def create_for_stream(cls, stream) -> FeefoAuthenticator:
@@ -29,6 +57,14 @@ class FeefoAuthenticator(OAuthAuthenticator, metaclass=SingletonMeta):
             A new authenticator.
         """
         return cls(
-            stream=stream,
             auth_endpoint="https://api.feefo.com/api/oauth/v2/token",
+            client_id=stream.config.get("client_id"),
+            client_secret=stream.config.get("client_secret"),
         )
+
+    @override
+    def authenticate_request(self, request):
+        if self._has_credentials:
+            return super().authenticate_request(request)
+
+        return request

--- a/tap_feefo/client.py
+++ b/tap_feefo/client.py
@@ -6,7 +6,7 @@ from functools import cached_property
 from http import HTTPStatus
 
 from singer_sdk.exceptions import RetriableAPIError
-from singer_sdk.pagination import BasePageNumberPaginator
+from singer_sdk.pagination import PageNumberPaginator
 from singer_sdk.streams import RESTStream
 from typing_extensions import override
 
@@ -25,7 +25,7 @@ class FeefoStream(RESTStream):
 
     @override
     def get_new_paginator(self):
-        return BasePageNumberPaginator(1)
+        return PageNumberPaginator(1)
 
     @override
     def get_url_params(self, context, next_page_token):

--- a/tap_feefo/client.py
+++ b/tap_feefo/client.py
@@ -21,24 +21,7 @@ class FeefoStream(RESTStream):
     @override
     @cached_property
     def authenticator(self):
-        client_id = "client_id" in self.config
-        client_secret = "client_secret" in self.config
-
-        if client_id and client_secret:
-            return FeefoAuthenticator.create_for_stream(self)
-
-        if client_id:
-            self.logger.warning(
-                "Client ID provided without a client secret, proceeding without "
-                "authentication"
-            )
-        elif client_secret:
-            self.logger.warning(
-                "Client secret provided without a client ID, proceeding without "
-                "authentication"
-            )
-
-        return None
+        return FeefoAuthenticator.create_for_stream(self)
 
     @override
     def get_new_paginator(self):


### PR DESCRIPTION
## Impact

Every sync fails immediately with `TypeError: 'NoneType' object is not callable` when the configuration does not supply both `client_id` and `client_secret`. Feefo serves review and product rating data without authentication, so a configuration with no client credentials is valid and worked before.

`main` is red. All 24 tests error, because the test suite runs the tap without credentials. The failure has been present on every run since #68 raised `singer-sdk` from `0.48.1` to `0.54.5` on 2026-08-07.

```
ERROR tests/test_core.py::TestTapFeefo::test_tap_stream_attribute_is_object[reviews.nps] - TypeError: 'NoneType' object is not callable
======================== 1 warning, 24 errors in 1.39s =========================
```

## Cause

`0.54.5` types the stream `authenticator` property as a callable and applies it to every request:

```python
authenticated_request = self.authenticator(prepared_request)
```

Earlier versions skipped a `None` authenticator. `FeefoStream.authenticator` returned `None` when either client credential was missing, so the SDK now calls `None`.

## Fix

The credential check moves from `FeefoStream.authenticator` to `FeefoAuthenticator.authenticate_request`. The stream always returns an authenticator. The authenticator returns the request unchanged when a complete pair of credentials is not available.

A `cached_property` holds the result of the check. The warning about an incomplete pair of credentials therefore logs once for each run. The placement in `authenticate_request` alone would log it once for each request.

## Deprecations

The same change also clears every `singer-sdk` deprecation warning that the test suite reports.

`FeefoAuthenticator` reads the credentials through the `client_id` and `client_secret` properties in place of `config`, and receives them as constructor arguments in place of `stream`. The SDK removes the `config` property and the `stream` parameter in `0.58`.

`get_new_paginator` returns `PageNumberPaginator` in place of `BasePageNumberPaginator`. The deprecated class is an empty subclass of the replacement, so pagination behaviour does not change.

## Verification

The test suite runs the tap against the public `example-retail-merchant` demo data with no credentials. It therefore covers the repaired path directly. On this branch the suite reports 24 passed, with no `singer-sdk` deprecation warning.

Claude Code also confirmed the unauthenticated behaviour by hand. Three prepared requests carry no `Authorization` header, and the tap logs the incomplete-credentials warning once rather than once for each request.

Note that the client credentials path stays untested. The test configuration supplies no `client_id` or `client_secret`, so no test exercises the token request, the token expiry retry in `validate_response`, or the credential hint in `response_error_message`. Those paths need a live account to cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
